### PR TITLE
FR: Add OpenAI Usage disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ As an Obsidian enthusiast and AI researcher, I experienced firsthand the challen
 
 By harnessing the power of AI, Smart Connections elevates your Obsidian workflow to new heights.
 
+## Disclosure about OpenAI API usage:
+This plugin sends your data back to OpenAI which utilises credits. The default limit for spending with OpenAI is $120 per month. It is recommended you check these settings and set it to your preferred max monthly limit prior to enabling this plugin. The larger your vault, the more it is going to cost to 'train' the AI.
+
+[Check your billing](https://platform.openai.com/account/billing/limits)
+
 ### Want to be part of the exciting journey of Smart Connections?
 We invite you to join the vibrant [discussion on GitHub](https://github.com/brianpetro/obsidian-smart-connections/discussions). Share your experiences, ask questions, or suggest new features – your input is invaluable to future of this project. Engaging with our community of Obsidian enthusiasts and AI aficionados is an excellent opportunity to learn from others, explore creative ways to use Smart Connections, and contribute to the continuous improvement of this powerful plugin. Let's work together to shape the future of AI-enhanced note-taking in Obsidian!
 

--- a/main.js
+++ b/main.js
@@ -2368,6 +2368,13 @@ class SmartConnectionsSettingsTab extends Obsidian.PluginSettingTab {
     });
     new Obsidian.Setting(containerEl).setName("api_key").setDesc("api_key").addText((text) => text.setPlaceholder("Enter your api_key").setValue(this.plugin.settings.api_key).onChange(async (value) => {
       this.plugin.settings.api_key = value.trim();
+      new Obsidian.Notice( "Smart Connections: Your API Key is set. We recommend that you test it!" )
+
+      let message_elem = document.createElement( "span" )
+      message_elem.innerHTML = "Smart Connections:\n\nThis plugin sends your data back to OpenAI which utilises credits. The default limit for spending with OpenAI is $120 per month. It is recommended you check these settings and set it to your preferred max monthly limit prior to enabling this plugin. The larger your vault, the more it is going to cost to 'train' the AI.\n\n<a href='https://platform.openai.com/account/billing/limits'>Check your billing</a>"
+
+      // setting the timeout to null makes the message show indefinitely
+      new Obsidian.Notice( message_elem, null )
       await this.plugin.saveSettings(true);
     }));
     // add a button to test the API key is working


### PR DESCRIPTION
Resolves #93

# This PR adds this message popup whenever you update the API key.
Since this `Obsidian.Notice` is declared with the `timeout` argument set to `null`, **this dialog stays open until you _manually_ dismiss it.**

![image](https://user-images.githubusercontent.com/12621101/227763684-1e799dd7-6998-4365-ab42-eec1980167fd.png)

Additionally, updates the README to have this same disclosure.