### PR TITLE
feat: stop rendering frontmatter

### DIFF
--- a/main.js
+++ b/main.js
@@ -1547,6 +1547,7 @@ class SmartConnectionsPlugin extends Obsidian.Plugin {
     let is_code = false;
     let char_accum = 0;
     const line_limit = limits.lines || file_lines.length;
+    let is_frontmatter = false;
     for (let i = 0; first_ten_lines.length < line_limit; i++) {
       let line = file_lines[i];
       // if line is undefined, break
@@ -1560,7 +1561,19 @@ class SmartConnectionsPlugin extends Obsidian.Plugin {
         line = line.slice(0, limits.chars_per_line) + "...";
       }
       // if line is "---", skip
-      if (line === "---")
+      if (line === "---") {
+        // frontmatter ends
+        if (is_frontmatter) {
+          is_frontmatter = false;
+        }
+        // frontmatter starts
+        if (i === 0) {
+          is_frontmatter = true;
+        }
+        continue;
+      }
+      // if line is part of the frontmatter, skip
+      if (is_frontmatter)
         continue;
       // skip if line is empty bullet or checkbox
       if (['- ', '- [ ] '].indexOf(line) > -1)


### PR DESCRIPTION
The content of some notes may not be fully revealed in search results if they have numerous frontmatter fields. The contrast is depicted in the following pictures:
Before:
![before22](https://github.com/brianpetro/obsidian-smart-connections/assets/41834091/c72ecb6b-3601-4f01-b840-ad203ddd4396)
After:
![after22](https://github.com/brianpetro/obsidian-smart-connections/assets/41834091/97389cac-d843-4e96-8398-20b5a183748b)

Original note:
![draft2](https://github.com/brianpetro/obsidian-smart-connections/assets/41834091/5c660a6d-40fa-4397-8b3c-38ff250e0575)

