### PR TITLE
Add setting for toggling inversion of enter and shift+enter to send message vs going to next line

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -392,6 +392,7 @@ var DEFAULT_SETTINGS = {
   skip_sections: false,
   smart_chat_model: "gpt-3.5-turbo-16k",
   view_open: true,
+  use_shift_to_send: true,
   version: ""
 };
 var MAX_EMBED_STRING_LENGTH = 25e3;
@@ -2190,6 +2191,10 @@ var SmartConnectionsSettingsTab = class extends Obsidian.PluginSettingTab {
       this.plugin.settings.skip_sections = value;
       await this.plugin.saveSettings(true);
     }));
+    new Obsidian.Setting(containerEl).setName("use_shift_to_send").setDesc("When enabled, Enter goes to the next line and Shift+Enter sends the message. Otherwise, Enter sents the message and Shift+Enter goes to the next line.").addToggle((toggle) => toggle.setValue(this.plugin.settings.use_shift_to_send).onChange(async (value) => {
+      this.plugin.settings.use_shift_to_send = value;
+      await this.plugin.saveSettings(true);
+    }));
     containerEl.createEl("h3", {
       text: "Test File Writing"
     });
@@ -2436,7 +2441,7 @@ var SmartConnectionsChatView = class extends Obsidian.ItemView {
       }
     });
     chat_input.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" && e.shiftKey) {
+      if (e.key === "Enter" && (!this.plugin.settings.use_shift_to_send || e.shiftKey)) {
         e.preventDefault();
         if (this.prevent_input) {
           console.log("wait until current response is finished");

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -6,5 +6,5 @@
   "minAppVersion": "1.1.0",
   "authorUrl": "https://wfhbrian.com",
   "isDesktopOnly": true,
-  "version": "1.6.34"
+  "version": "1.6.35"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
   "minAppVersion": "1.1.0",
   "authorUrl": "https://wfhbrian.com",
   "isDesktopOnly": true,
-  "version": "1.6.34"
+  "version": "1.6.35"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-smart-connections",
-  "version": "1.6.34",
+  "version": "1.6.35",
   "description": "Link and chat with your notes using ChatGPT and embedding artificial intelligence from OpenAI.",
   "main": "main.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -2760,7 +2760,7 @@ class SmartConnectionsChatView extends Obsidian.ItemView {
     });
 
     chat_input.addEventListener("keydown", (e) => {
-      if (e.key === 'Enter' && (!this.plugin.settings.use_shift_to_send || e.shiftKey)) {
+      if (e.key === "Enter" && (!this.plugin.settings.use_shift_to_send || e.shiftKey)) {
         e.preventDefault();
         if(this.prevent_input){
           console.log("wait until current response is finished");

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS = {
   skip_sections: false,
   smart_chat_model: "gpt-3.5-turbo-16k",
   view_open: true,
+  use_shift_to_send: true,
   version: "",
 };
 const MAX_EMBED_STRING_LENGTH = 25000;
@@ -2444,6 +2445,13 @@ class SmartConnectionsSettingsTab extends Obsidian.PluginSettingTab {
       this.plugin.settings.skip_sections = value;
       await this.plugin.saveSettings(true);
     }));
+
+    // use shift to send
+    new Obsidian.Setting(containerEl).setName("use_shift_to_send").setDesc("When enabled, Enter goes to the next line and Shift+Enter sends the message. Otherwise, Enter sents the message and Shift+Enter goes to the next line.").addToggle((toggle) => toggle.setValue(this.plugin.settings.use_shift_to_send).onChange(async (value) => {
+      this.plugin.settings.use_shift_to_send = value;
+      await this.plugin.saveSettings(true);
+    }));
+
     // test file writing by creating a test file, then writing additional data to the file, and returning any error text if it fails
     containerEl.createEl("h3", {
       text: "Test File Writing"
@@ -2752,7 +2760,7 @@ class SmartConnectionsChatView extends Obsidian.ItemView {
     });
 
     chat_input.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" && e.shiftKey) {
+      if (e.key === 'Enter' && (!this.plugin.settings.use_shift_to_send || e.shiftKey)) {
         e.preventDefault();
         if(this.prevent_input){
           console.log("wait until current response is finished");


### PR DESCRIPTION
Simple annoyance fix. Defaults to the same behavior as original, and adds option to change it to the common default seen in most chat apps.

Issue: #324 