### PR TITLE
Add option to open Smart Connections view in main tab or right sidebar

### DIFF
--- a/src/default_settings.js
+++ b/src/default_settings.js
@@ -39,6 +39,7 @@ function default_settings() {
       // group_nearest_by_file: false, // DEPRECATED
       // path_only: "", // DEPRECATED
       // header_exclusions: "", // DEPRECATED use excluded_headings instead
+      open_in_main_tab: false,
     },
     api: null,
     embeddings_loaded: false,

--- a/src/sc_settings.js
+++ b/src/sc_settings.js
@@ -62,6 +62,7 @@ class ScSettings extends SmartSettings {
       muted_notices: this.plugin.settings.muted_notices || false,
       ...((await this.chat_settings.get_view_data()) || {}),
       ...((await this.embed_settings.get_view_data()) || {}),
+      open_in_main_tab: this.plugin.settings.open_in_main_tab
     };
     return view_data;
   }

--- a/src/smart_obsidian_view.js
+++ b/src/smart_obsidian_view.js
@@ -32,7 +32,7 @@ class SmartObsidianView extends ItemView {
       // set loading message
       this.containerEl.children[1].innerHTML = "Loading Smart Connections...";
       // wait for entities to be initialized
-      while (!this.env?.entities_loaded){
+      while (!this.env?.entities_loaded) {
         await new Promise(r => setTimeout(r, 2000));
       }
     }
@@ -42,9 +42,19 @@ class SmartObsidianView extends ItemView {
   static get_leaf(workspace) { return workspace.getLeavesOfType(this.view_type)?.find((leaf) => leaf.view instanceof this); }
   static get_view(workspace) { return this.get_leaf(workspace)?.view; }
   static open(workspace, active = true) {
-    if (this.get_leaf(workspace)) this.get_leaf(workspace).setViewState({ type: this.view_type, active });
-    else workspace.getRightLeaf(false).setViewState({ type: this.view_type, active });
-    if(workspace.rightSplit.collapsed) workspace.rightSplit.toggle();
+    const openInMainTab = workspace.plugin.settings.open_in_main_tab;
+    if (this.get_leaf(workspace)) {
+      this.get_leaf(workspace).setViewState({ type: this.view_type, active });
+    } else {
+      if (openInMainTab) {
+        workspace.getLeaf(true).setViewState({ type: this.view_type, active });
+      } else {
+        workspace.getRightLeaf(false).setViewState({ type: this.view_type, active });
+      }
+    }
+    if (workspace.rightSplit.collapsed) {
+      workspace.rightSplit.toggle();
+    }
   }
   static is_open(workspace) { return this.get_leaf(workspace)?.view instanceof this; }
   get container() { return this.containerEl.children[1]; }

--- a/src/views/smart_settings.ejs
+++ b/src/views/smart_settings.ejs
@@ -153,6 +153,16 @@
   data-callback="update_language"
 ></div>
 <span id="self-referential-pronouns">Current: my, I, me, mine, our, ours, us, we</span>
+<h1>Interface</h1>
+<div class="setting-item">
+  <div class="setting-item-info">
+    <b>Open in Main Tab</b>
+    <p>Choose whether to open the Smart Connections view in the main tab or the right sidebar.</p>
+  </div>
+  <div class="setting-item-control">
+    <input type="checkbox" class="setting-component" data-setting="open_in_main_tab" data-type="toggle" />
+  </div>
+</div>
 <h1>Exclusions</h1>
 <p id="file-counts">Included files: <%= included_files %> / Total files: <%= total_files %></p>
 <div class="setting-component"


### PR DESCRIPTION
### Description
This pull request adds a new option to the Smart Connections plugin settings, allowing users to choose whether the view should open in the main tab or the right sidebar.

### Changes Made
- Added `open_in_main_tab` setting in `default_settings.js`.
- Updated `sc_settings.js` to include `open_in_main_tab` setting.
- Modified `smart_obsidian_view.js` to respect `open_in_main_tab` setting.
- Updated `smart_settings.ejs` to allow user configuration of `open_in_main_tab`.

### Motivation
The new setting provides users with more flexibility in how they prefer to view the Smart Connections, enhancing the user experience.
