### PR TITLE
Pressing enter while in chat box sends message instead of new line

### DIFF
--- a/src/views/smart_chat.js
+++ b/src/views/smart_chat.js
@@ -78,8 +78,17 @@ export async function post_process(obsidian_view, frag, opts) {
 
 
   const chat_input = frag.querySelector('.sc-chat-form textarea');
+  const send_button = frag.querySelector('.send-button');
   if (chat_input) {
     chat_input.addEventListener('keydown', obsidian_view.handle_chat_input_keydown.bind(obsidian_view));
+
+    // On enter press send button
+    chat_input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        send_button.click();
+      }
+    });
   }
 
   // Add close button handler


### PR DESCRIPTION
Now, when pressing the enter button, while inside of the chat box, the send button is pressed instead of making a new line.

This is a behaviour, that I like much better, since new lines can still be added using shift+enter and now you don't need to use the mouse or tab to send the message which makes it fell much faster.

The same behaviour can also be seen in most other AI chats, such as the web interfaces of ChatGPT or Gemini.