### PR TITLE
Fix the bottom bar to attach at the bottom the sc view

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -490,7 +490,7 @@
 }
 
 .sc-bottom-bar {
-  position: fixed;
+  position: absolute;
   bottom: 0;
   right: 0;
   left: 0;
@@ -592,11 +592,11 @@
     font-weight: var(--font-medium);
     cursor: pointer;
     user-select: none;
-  
+
     &:hover {
       background-color: var(--background-primary-hover);
     }
-  
+
     &:focus {
       outline: 2px solid var(--text-muted);
       outline-offset: 2px;


### PR DESCRIPTION
The bottom bar of smart connections currently is at the bottom of the entire Obsidian. I think it should be at the bottom of the smart connections view.

Before:

<img width="1589" alt="Screenshot 2025-06-23 at 22 48 36" src="https://github.com/user-attachments/assets/41f9192e-ce91-4473-b71c-d5c260e86367" />


After:

<img width="1589" alt="Screenshot 2025-06-23 at 22 48 16" src="https://github.com/user-attachments/assets/3f7636db-e8c8-432d-9c61-92169ea7544c" />


