### PR TITLE
Security: Unhandled JSON.parse on User-Controlled Codeblock Content

### DIFF
--- a/src/views/connections_codeblock.js
+++ b/src/views/connections_codeblock.js
@@ -8,7 +8,14 @@ export async function register_smart_connections_codeblock(plugin) {
     async (cb_content, container, mpp_ctx) => {
       container.empty();
       container.createEl('span', { text: 'Loading…' });
-      const cb_config = JSON.parse(cb_content.trim() || '{}');
+      let cb_config = {};
+      try {
+        cb_config = JSON.parse(cb_content.trim() || '{}');
+      } catch (e) {
+        container.empty();
+        container.createEl('p', { text: 'Invalid JSON in smart-connections block: ' + e.message });
+        return;
+      }
       const env = plugin.env;
       const entity =
         env.smart_sources.get(mpp_ctx.sourcePath) ??


### PR DESCRIPTION
## Summary

Security: Unhandled JSON.parse on User-Controlled Codeblock Content

## Problem

**Severity**: `High` | **File**: `src/views/connections_codeblock.js:L10`

In connections_codeblock.js the markdown code block processor calls JSON.parse(cb_content.trim() || '{}') without a try/catch. A note author can write a smart-connections codeblock with invalid JSON (e.g., trailing commas, unquoted keys) and this will throw an uncaught exception, crashing the renderer for that block and potentially leaving the container in a broken state. Because Obsidian re-runs the processor on every render, the crash will be persistent for that note.

## Solution

Wrap the parse in try/catch: let cb_config = {}; try { cb_config = JSON.parse(cb_content.trim() || '{}'); } catch (e) { container.empty(); container.createEl('p', { text: 'Invalid JSON in smart-connections block: ' + e.message }); return; }

## Changes

- `src/views/connections_codeblock.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*