### PR TITLE
Bundle d3 at build time instead of importing it from a CDN at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "swagger-jsdoc": "^6.2.8"
   },
   "dependencies": {
+    "d3-force": "^3.0.0",
+    "d3-selection": "^3.0.0",
     "js-tiktoken": "^1.0.19",
     "obsidian": "latest",
     "obsidian-smart-env": "file:../obsidian-smart-env",

--- a/src/components/connections-graph/v1.js
+++ b/src/components/connections-graph/v1.js
@@ -1,4 +1,6 @@
 import styles_css from './v1.css';
+import { select } from 'd3-selection';
+import { forceCollide, forceManyBody, forceRadial, forceSimulation } from 'd3-force';
 import { get_item_display_name } from 'obsidian-smart-env/src/utils/get_item_display_name.js';
 import { cos_sim } from 'smart-utils/cos_sim.js';
 import { register_item_drag } from 'obsidian-smart-env/src/utils/register_item_drag.js';
@@ -105,67 +107,20 @@ function parse_prefixed_key(prefixed_key) {
 
 
 /**
- * CDN settings for D3 used by the graph component.
- * Uses D3's CDN-hosted ESM bundle so the loader does not create a script element.
+ * D3 primitives used by the connections graph, bundled at build time
+ * (see the d3-selection / d3-force dependencies in package.json).
+ * Bundling avoids fetching and executing remote code at runtime, per
+ * Obsidian's developer policy prohibiting loading code from a CDN.
  */
-const D3_CDN_URL = 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
-const D3_EXPECTED_MAJOR = '7.';
-let d3_import_promise = null;
+const d3_lib = { select, forceCollide, forceManyBody, forceRadial, forceSimulation };
 
 /**
- * Resolve the D3 CDN URL as runtime data so the bundler preserves the import expression.
- * @returns {string}
- */
-function get_d3_cdn_url() {
-  return D3_CDN_URL;
-}
-
-/**
- * Validate a candidate d3 instance and log if it looks unexpected.
- * @param {any} d3
- */
-function validate_d3_instance(d3) {
-  if (!d3) return;
-  const version = String(d3.version || '');
-  if (version && !version.startsWith(D3_EXPECTED_MAJOR)) {
-    console.warn(
-      `[connections_graph] Loaded d3 version "${version}" but expected v${D3_EXPECTED_MAJOR}x`
-    );
-  }
-}
-
-/**
- * Lazy-loads D3 from the CDN ESM bundle once without creating a script element.
- * If a global d3 already exists it is reused.
- * @returns {Promise<typeof import('d3')>}
+ * Returns the bundled d3 primitives.
+ * Kept async so existing `await load_d3()` call sites remain unchanged.
+ * @returns {Promise<typeof d3_lib>}
  */
 async function load_d3() {
-  const g = typeof activeWindow !== 'undefined'
-    ? activeWindow
-    : (typeof globalThis !== 'undefined'
-      ? globalThis
-      : (typeof window !== 'undefined' ? window : {}));
-
-  if (g.d3) {
-    validate_d3_instance(g.d3);
-    return g.d3;
-  }
-
-  if (!d3_import_promise) {
-    const d3_cdn_url = get_d3_cdn_url();
-    d3_import_promise = import(d3_cdn_url)
-      .then((d3) => {
-        validate_d3_instance(d3);
-        if (!g.d3) g.d3 = d3;
-        return d3;
-      })
-      .catch((err) => {
-        d3_import_promise = null;
-        throw err;
-      });
-  }
-
-  return d3_import_promise;
+  return d3_lib;
 }
 
 /**


### PR DESCRIPTION
## Summary

The connections graph loads d3 at runtime via a dynamic import of a live remote ES module:

```js
// src/components/connections-graph/v1.js
const D3_CDN_URL = 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
...
d3_import_promise = import(get_d3_cdn_url());
```

This fetches and executes remote code inside Obsidian's Electron renderer every time a user first opens the Connections Graph view. The URL is pinned only to major version `d3@7` (so the exact code served can change), and dynamic `import()` of a remote module has no Subresource Integrity check. If jsdelivr — or that package version on jsdelivr — served different bytes, unvetted code would run with full plugin privileges. This surfaced during an independent source-code review; it is a hardening improvement, not evidence of any active compromise.

Obsidian's developer policies also ask plugins not to load remote code, so bundling is the idiomatic fix here as well.

## Change

The graph only uses a small slice of d3:

- `select` — from `d3-selection`
- `forceSimulation`, `forceCollide`, `forceManyBody`, `forceRadial` — from `d3-force`

This PR imports those statically and lets esbuild bundle them, and removes the CDN URL, the runtime `import()`, and the now-unused version-warning/global-reuse loader logic. `load_d3()` is kept (returning the bundled primitives) so the existing `await load_d3()` call site is untouched.

- `package.json`: adds `d3-selection@^3` and `d3-force@^3` (the d3@7-era versions) as dependencies.
- `v1.js`: static imports replace the dynamic CDN import.

## Verification

Full plugin build depends on local workspace packages not present in a bare clone, so I verified the specific change in isolation:

- `d3-selection@3.0.0` and `d3-force@3.0.0` install and expose all five named exports as functions; `forceSimulation(...).force(...)` runs.
- esbuild bundles the five imports to ~51 KB (vs ~275 KB for full d3), confirming the imports resolve and tree-shake under the same bundler the plugin uses.

Rationale for bundling over pinning + SRI: dynamic `import()` of a remote module can't attach an SRI hash the way a `<script>` tag can (the earlier `script.integrity` path was removed in 6d03daa), and bundling only the used submodules keeps the size cost small while removing the remote-trust dependency entirely.